### PR TITLE
Add virtual try-on feature

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -72,3 +72,14 @@ form button { width:100%; padding:10px; background:var(--primary); border:none; 
 form button:hover, .btn:hover { background:var(--primary-dark); }
 
 .form-card { max-width:400px; margin:20px auto; padding:20px; background:#fff; border-radius:6px; box-shadow:0 2px 6px rgba(0,0,0,0.1); }
+
+/* Virtual try-on */
+#ar-container {
+  width: 100%;
+  height: 500px;
+  position: relative;
+}
+a-scene {
+  width: 100%;
+  height: 100%;
+}

--- a/assets/images/Glasses.obj
+++ b/assets/images/Glasses.obj
@@ -1,0 +1,6 @@
+# Placeholder OBJ model for virtual try-on
+v 0 0 0
+v 0.5 0 0
+v 0.5 0.5 0
+v 0 0.5 0
+f 1 2 3 4

--- a/assets/images/glasses-1-.glb
+++ b/assets/images/glasses-1-.glb
@@ -1,0 +1,1 @@
+placeholder glb file

--- a/header.php
+++ b/header.php
@@ -19,6 +19,7 @@
           <li><a href="#">Óculos de Grau</a></li>
           <li><a href="#">Lançamentos</a></li>
           <li><a href="#">Ofertas</a></li>
+          <li><a href="try_on.php">Provador</a></li>
         </ul>
       </nav>
       <div class="header-icons">

--- a/index.php
+++ b/index.php
@@ -46,6 +46,7 @@ include 'header.php';
           <h4><?= htmlspecialchars($product['NOME']) ?></h4>
           <p>R$ <?= number_format($product['VALOR_UNITARIO'], 2, ',', '.') ?></p>
           <a class="btn" href="add_to_cart.php?id=<?= $product['ID'] ?>">Adicionar</a>
+          <a class="btn" href="try_on.php">Provador</a>
         </div>
       <?php endforeach; ?>
     </div>

--- a/try_on.php
+++ b/try_on.php
@@ -4,7 +4,7 @@ include 'header.php';
 <main class="container">
   <h1>Provador Virtual</h1>
     <div id="ar-container">
-      <a-scene mindar-face embedded color-space="sRGB" vr-mode-ui="enabled: false" device-orientation-permission-ui="enabled: false">
+      <a-scene mindar-face="autoStart: false" embedded color-space="sRGB" vr-mode-ui="enabled: false" device-orientation-permission-ui="enabled: true">
         <a-assets>
           <a-asset-item id="glassesModel" src="assets/images/glasses-1-.glb"></a-asset-item>
         </a-assets>
@@ -20,12 +20,17 @@ include 'header.php';
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     const sceneEl = document.querySelector('a-scene');
-    sceneEl.addEventListener('loaded', () => {
+    const startMindAR = () => {
       const mindarSystem = sceneEl.systems['mindar-face-system'];
       if (mindarSystem && mindarSystem.start) {
         mindarSystem.start();
       }
-    });
+    };
+    if (sceneEl.hasLoaded) {
+      startMindAR();
+    } else {
+      sceneEl.addEventListener('loaded', startMindAR);
+    }
   });
 </script>
 <?php

--- a/try_on.php
+++ b/try_on.php
@@ -1,0 +1,22 @@
+<?php
+include 'header.php';
+?>
+<main class="container">
+  <h1>Provador Virtual</h1>
+  <div id="ar-container">
+    <a-scene mindar-face embedded color-space="sRGB" vr-mode-ui="enabled: false" device-orientation-permission-ui="enabled: false">
+      <a-assets>
+        <a-asset-item id="glassesModel" src="assets/images/glasses-1-.glb"></a-asset-item>
+      </a-assets>
+      <a-camera active="false" position="0 0 0"></a-camera>
+      <a-entity mindar-face-target="anchorIndex: 168">
+        <a-gltf-model rotation="0 0 0" position="0 -0.4 0.5" scale="0.75 0.75 0.75" src="#glassesModel"></a-gltf-model>
+      </a-entity>
+    </a-scene>
+  </div>
+</main>
+<script src="https://cdn.jsdelivr.net/npm/aframe@1.4.1/dist/aframe.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/mind-ar@1.1.4/dist/mindar-face-aframe.prod.js"></script>
+<?php
+include 'footer.php';
+?>

--- a/try_on.php
+++ b/try_on.php
@@ -3,20 +3,31 @@ include 'header.php';
 ?>
 <main class="container">
   <h1>Provador Virtual</h1>
-  <div id="ar-container">
-    <a-scene mindar-face embedded color-space="sRGB" vr-mode-ui="enabled: false" device-orientation-permission-ui="enabled: false">
-      <a-assets>
-        <a-asset-item id="glassesObj" src="assets/images/Glasses.obj"></a-asset-item>
-      </a-assets>
-      <a-camera active="false" position="0 0 0"></a-camera>
-      <a-entity mindar-face-target="anchorIndex: 168">
-        <a-entity obj-model="obj: #glassesObj" rotation="0 0 0" position="0 -0.4 0.5" scale="0.75 0.75 0.75"></a-entity>
-      </a-entity>
-    </a-scene>
-  </div>
+    <div id="ar-container">
+      <a-scene mindar-face embedded color-space="sRGB" vr-mode-ui="enabled: false" device-orientation-permission-ui="enabled: false">
+        <a-assets>
+          <a-asset-item id="glassesModel" src="assets/images/glasses-1-.glb"></a-asset-item>
+        </a-assets>
+        <a-camera active="false" position="0 0 0"></a-camera>
+        <a-entity mindar-face-target="anchorIndex: 168">
+          <a-gltf-model src="#glassesModel" rotation="0 0 0" position="0 -0.4 0.5" scale="0.75 0.75 0.75"></a-gltf-model>
+        </a-entity>
+      </a-scene>
+    </div>
 </main>
 <script src="https://cdn.jsdelivr.net/npm/aframe@1.4.1/dist/aframe.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/mind-ar@1.1.4/dist/mindar-face-aframe.prod.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const sceneEl = document.querySelector('a-scene');
+    sceneEl.addEventListener('loaded', () => {
+      const mindarComponent = sceneEl.components['mindar-face-system'];
+      if (mindarComponent && mindarComponent.start) {
+        mindarComponent.start();
+      }
+    });
+  });
+</script>
 <?php
 include 'footer.php';
 ?>

--- a/try_on.php
+++ b/try_on.php
@@ -21,9 +21,9 @@ include 'header.php';
   document.addEventListener('DOMContentLoaded', () => {
     const sceneEl = document.querySelector('a-scene');
     sceneEl.addEventListener('loaded', () => {
-      const mindarComponent = sceneEl.components['mindar-face-system'];
-      if (mindarComponent && mindarComponent.start) {
-        mindarComponent.start();
+      const mindarSystem = sceneEl.systems['mindar-face-system'];
+      if (mindarSystem && mindarSystem.start) {
+        mindarSystem.start();
       }
     });
   });

--- a/try_on.php
+++ b/try_on.php
@@ -6,11 +6,11 @@ include 'header.php';
   <div id="ar-container">
     <a-scene mindar-face embedded color-space="sRGB" vr-mode-ui="enabled: false" device-orientation-permission-ui="enabled: false">
       <a-assets>
-        <a-asset-item id="glassesModel" src="assets/images/glasses-1-.glb"></a-asset-item>
+        <a-asset-item id="glassesObj" src="assets/images/Glasses.obj"></a-asset-item>
       </a-assets>
       <a-camera active="false" position="0 0 0"></a-camera>
       <a-entity mindar-face-target="anchorIndex: 168">
-        <a-gltf-model rotation="0 0 0" position="0 -0.4 0.5" scale="0.75 0.75 0.75" src="#glassesModel"></a-gltf-model>
+        <a-entity obj-model="obj: #glassesObj" rotation="0 0 0" position="0 -0.4 0.5" scale="0.75 0.75 0.75"></a-entity>
       </a-entity>
     </a-scene>
   </div>


### PR DESCRIPTION
## Summary
- add a virtual try-on page using A-Frame + MindAR
- include navigation link and product button for try-on
- add placeholder 3D model file
- basic styling for AR container

## Testing
- `php -l header.php`
- `php -l try_on.php`
- `php -l index.php`
- `find . -name '*.php' -maxdepth 1 -print0 | xargs -0 -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_6877258bf0b883299f3605d64919ebff